### PR TITLE
Fix data-service validation to pull candles

### DIFF
--- a/src/services/rates/data.ts
+++ b/src/services/rates/data.ts
@@ -1,7 +1,7 @@
 import { isSymmetric } from './util';
 import { AssetIdsPair } from '../../types';
 
-export const WavesId: string = 'WAVES';
+export const WavesId: string = 'TN';
 
 export const pairIsSymmetric = isSymmetric((p: AssetIdsPair) => [
   p.amountAsset,

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -5,7 +5,7 @@ import { toBigNumber } from './bigNumber';
 const parser = createParser<BigNumber>({
   strict: false,
   isInstance: (bn: any): bn is BigNumber => BigNumber.isBigNumber(bn),
-  stringify: (bn: BigNumber) => bn.toFixed(),
+  stringify: (bn: BigNumber) => bn == undefined ? "" : bn.toFixed(),
   parse: toBigNumber,
 });
 

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -2,7 +2,7 @@ const base58Chars: string = '[1-9A-HJ-NP-Za-km-z]+';
 
 export const interval: RegExp = /^\d+[smhdwMY]$/;
 export const base58: RegExp = new RegExp(`^${base58Chars}$`);
-export const assetId: RegExp = new RegExp(`^(?:WAVES|${base58Chars})$`);
+export const assetId: RegExp = new RegExp(`^(?:TN|${base58Chars})$`);
 export const noNullChars: RegExp = /^[^\x00]*$/;
 
 // string doesn't have dangding unescaped slash at the end

--- a/src/utils/validation/joi.js
+++ b/src/utils/validation/joi.js
@@ -29,7 +29,7 @@ module.exports = rawJoi
     name: 'string',
     language: {
       base58: 'must be a valid base58 string',
-      assetId: 'must be a valid base58 string or "WAVES"',
+      assetId: 'must be a valid base58 string or "TN"',
       base64Prefixed: 'must be a string of "base64:${base64EncodedString}"',
       noNullChars: 'must not contain unicode null characters',
       saneForDbLike: 'must not end with unescaped slash symbol',


### PR DESCRIPTION
Fixed the following
1. Loading Asset pairs was hard coded to fill only asset pairs with Waves
2. Our to.Fixed function in bignumber I assume is now old and I am assuming that maybe the waves one will auto return "" if it undefined, I have fixed this in the data-service for now
3. Regex allows for assetids to be either base58 strings OR it was hard coded to allow for WAVES, I had to change that to TN