### PR TITLE
Add duplicate filter for transactions that are considered "duplicate"

### DIFF
--- a/src/daemons/candles/sql/query.js
+++ b/src/daemons/candles/sql/query.js
@@ -90,7 +90,7 @@ const selectExchanges = pg({ t: 'txs_7' }).column(
   { candle_time: pgRawDateTrunc('t.time_stamp')('minute') },
   `amount`,
   `price`
-);
+).distinct(['amount_asset','price_asset','time_stamp']);
 
 /** selectExchangesAfterTimestamp :: Date -> QueryBuilder */
 const selectExchangesAfterTimestamp = fromTimestamp =>
@@ -146,17 +146,7 @@ const updatedFieldsExcluded = [
 
 /** insertOrUpdateCandles :: (String, Array[Object]) -> String query */
 const insertOrUpdateCandles = (tableName, candles) => {
-    if (candles.length) {
-      let dict = [];
-      candles = candles.filter(candle => {
-      let candleName = candle.time_stamp+candle.amount_asset+candle.price_asset;
-      if(dict.indexOf(candleName) == -1)
-      {
-        dict.push(candleName);
-        return true;
-      }
-      return false;
-    });
+  if (candles.length) {
     return pg
       .raw(
         `${pg({ t: tableName }).insert(

--- a/src/daemons/candles/sql/query.js
+++ b/src/daemons/candles/sql/query.js
@@ -146,7 +146,17 @@ const updatedFieldsExcluded = [
 
 /** insertOrUpdateCandles :: (String, Array[Object]) -> String query */
 const insertOrUpdateCandles = (tableName, candles) => {
-  if (candles.length) {
+    if (candles.length) {
+      let dict = [];
+      candles = candles.filter(candle => {
+      let candleName = candle.time_stamp+candle.amount_asset+candle.price_asset;
+      if(dict.indexOf(candleName) == -1)
+      {
+        dict.push(candleName);
+        return true;
+      }
+      return false;
+    });
     return pg
       .raw(
         `${pg({ t: tableName }).insert(


### PR DESCRIPTION
Data-service assumes that no transaction can occur at the same time for the same asset pairs.
This is not the case in TN, therefore the price used for candles will be determined by distinct filter.